### PR TITLE
[gui] Add dark theme toggle

### DIFF
--- a/frontend/gui/src/renderer/App.vue
+++ b/frontend/gui/src/renderer/App.vue
@@ -1,11 +1,15 @@
 <template>
   <div id="app">
-    <v-app id="lc3tools" light>
+    <v-app id="lc3tools" v-bind:dark="dark_mode">
       <!-- Toolbar -->
       <v-toolbar app fixed dense>
         <v-toolbar-title><strong>LC3</strong>Tools</v-toolbar-title>
         <v-spacer></v-spacer>
         <v-toolbar-items>
+          <v-btn large flat exact v-on:click="dark_mode = !dark_mode">
+            <v-icon large v-if="!dark_mode">brightness_5</v-icon>
+            <v-icon large v-else>brightness_3</v-icon>
+          </v-btn>
           <v-btn large flat exact to="/assembler">
             <v-icon large>code</v-icon>
           </v-btn>
@@ -14,8 +18,9 @@
           </v-btn>
         </v-toolbar-items>
       </v-toolbar>
+
       <keep-alive>
-        <router-view></router-view>
+        <router-view :dark_mode="dark_mode"></router-view>
       </keep-alive>
 
       <v-dialog
@@ -78,7 +83,8 @@ export default {
         download_size: 0
       },
       update_dialog: false,
-      download_bar: false
+      download_bar: false,
+      dark_mode: false
     };
   },
 

--- a/frontend/gui/src/renderer/components/Assembler.vue
+++ b/frontend/gui/src/renderer/components/Assembler.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app id="assembler" light>
+  <v-app id="assembler" v-bind:dark="dark_mode">
 
     <!-- Sidebar -->
     <v-navigation-drawer
@@ -54,7 +54,7 @@
         <v-layout row wrap>
           <v-flex xs12 shrink class="editor-console-wrapper">
             <h3 id="filename" class="view-header">{{ getFilename }}</h3>
-            <editor id="editor" class = "elevation-2" v-model="editor.current_content" @init="editorInit" lang="text" theme="textmate" height="100%" width="98%"> </editor>
+            <editor id="editor" class = "elevation-2" v-model="editor.current_content" @init="editorInit" lang="text" v-bind:theme="dark_mode ? 'twilight' : 'textmate'" height="100%" width="98%"> </editor>
             <div id="console" class = "elevation-4" v-html="console_str"></div>
           </v-flex>
         </v-layout>
@@ -85,7 +85,8 @@ export default {
         current_file: "",
         content_changed: false
       },
-      console_str: ""
+      console_str: "",
+      editor_theme: "textmate"
     };
   },
   components: {
@@ -152,6 +153,7 @@ export default {
       require("brace/mode/javascript");
       require("brace/mode/less");
       require("brace/theme/textmate");
+      require("brace/theme/twilight");
     }
   },
   computed: {
@@ -178,7 +180,8 @@ export default {
         this.editor.content_changed = false;
       }
     }
-  }
+  },
+  props: { dark_mode: Boolean }
 };
 </script>
 

--- a/frontend/gui/src/renderer/components/Simulator.vue
+++ b/frontend/gui/src/renderer/components/Simulator.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app id="simulator" light>
+  <v-app id="simulator" v-bind:dark="dark_mode">
 
     <!-- Sidebar -->
     <v-navigation-drawer
@@ -112,7 +112,7 @@
 
               <div id="console-wrapper">
                 <h3 class="view-header">Console (click to focus)</h3>
-                <div id="console" v-html="console_str" @keyup="handleConsoleInput" tabindex="0"></div>
+                <div v-bind:id="dark_mode ? 'console-dark' : 'console'" v-html="console_str" @keyup="handleConsoleInput" tabindex="0"></div>
               </div>
 
             </div>
@@ -452,7 +452,8 @@ export default {
   computed: {
   },
   watch: {
-  }
+  },
+  props: { dark_mode: Boolean }
 };
 </script>
 
@@ -541,6 +542,31 @@ export default {
 }
 
 #console:focus {
+  font-size: 1.25em;
+  outline: none;
+  box-shadow: 0px 0px 6px 3px rgba(33,150,223,.6)
+}
+
+/* 
+Hack to get a dark console.
+Properties are nearly same as normal #console,
+just differently colored
+todo: find a way to avoid duplication and just modify colors?
+*/
+#console-dark {
+  flex: 1;
+  order: 2;
+  height: 100%;
+  width: 100%;
+  background-color: rgba(66,66,66,1);
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 1.25em;
+  padding: 8px;
+  overflow: auto;
+  box-shadow: 0 2px 4px -1px rgba(0,0,0,.2),0 4px 5px 0 rgba(0,0,0,.14),0 1px 10px 0 rgba(0,0,0,.12);
+}
+
+#console-dark:focus {
   font-size: 1.25em;
   outline: none;
   box-shadow: 0px 0px 6px 3px rgba(33,150,223,.6)


### PR DESCRIPTION
Used a prop from App.vue and Vuetify's default dark mode to add a dark mode toggle to the toolbar.

Exceptions not colored by Vuetify:
- Used "twilight" theme for assembler editor in dark mode. 
- Used same gray as sidebar for simulator console.