### PR TITLE
clear priority bits on restart

### DIFF
--- a/backend/interface.cpp
+++ b/backend/interface.cpp
@@ -113,6 +113,7 @@ void lc3::sim::restart(void)
 {
     uint32_t mcr = getMem(MCR);
     setMem(MCR, mcr | 0x8000);
+    setPSR(getPSR() & (~0x0700));
     if(getMachineState().pc > SYSTEM_END && getMachineState().pc < MMIO_START) {
         setPSR(getPSR() | 0x8000);
     } else {


### PR DESCRIPTION
The current ISR check has a problem that stops an ISR from triggering when a user resets the simulator while in an ISR.  This fixes the problem by resetting the priority bits on restart.