### PR TITLE
Plug a couple of memory leaks

### DIFF
--- a/backend/mem.cpp
+++ b/backend/mem.cpp
@@ -64,6 +64,7 @@ namespace core
 #ifdef _ENABLE_DEBUG_ASM
             std::cout << "line: " << out.line << "\n";
 #endif
+            delete[] chars;
         }
         return in;
     }

--- a/backend/simulator.cpp
+++ b/backend/simulator.cpp
@@ -7,7 +7,6 @@
 #include <sstream>
 
 #include "device_regs.h"
-#include "lc3os.h"
 #include "simulator.h"
 #include "utils.h"
 

--- a/backend/utils.cpp
+++ b/backend/utils.cpp
@@ -20,7 +20,10 @@ std::string lc3::utils::udecToBin(uint32_t value, uint32_t num_bits)
     }
     bits[num_bits] = 0;
 
-    return std::string(bits);
+    std::string ret(bits);
+    delete[] bits;
+
+    return ret;
 }
 
 uint32_t lc3::utils::sextTo32(uint32_t value, uint32_t num_bits)


### PR DESCRIPTION
As part of testing [some bindings](https://github.com/rrbutani/lc3tools-sys), I was running [a program](https://github.com/rrbutani/lc3tools-sys/blob/main/examples/mul.rs) that repeatedly calls `reinitialize` and I was getting sporadic crashes when running this program on Windows (`STATUS_STACK_BUFFER_OVERRUN` errors, like [this](https://github.com/rrbutani/lc3tools-sys/runs/813090725?check_suite_focus=true#step:15:10)) because new allocations were failing.

Adding calls to `delete` in a couple of places fixed this for me.

I'm not very confident that I caught all the memory leaks but `valgrind` seems happy — at least for the program I'm running.